### PR TITLE
Move ssh parameters to config file

### DIFF
--- a/monroe/cli.py
+++ b/monroe/cli.py
@@ -199,12 +199,12 @@ def gen_ssh_mnr():
         f.write(key.publickey().exportKey(format='OpenSSH'))
         print("Public key written to ~/.monroe/mnr_rsa.pub.")
     with open(sshkey_priv, 'wb') as f:
+        os.chmod(sshkey_priv, 0o600)
         if secret != "":
             f.write(key.exportKey(passphrase=secret))
         else:
             f.write(key.exportKey())
         print("Private key written to ~/.monroe/mnr_rsa.")
-    os.chmod(sshkey_priv, 0o600)
     print("These are the default keys used by the cli.")
 
 
@@ -437,6 +437,7 @@ def setup(args):
                 if not os.path.exists(mnr_dir):
                     os.makedirs(mnr_dir)
                 with open(mnr_key, 'wb') as f:
+                    os.chmod(mnr_key, 0o600)
                     f.write(pk)
                 with open(mnr_crt, 'wb') as f:
                     f.write(ct)

--- a/monroe/cli.py
+++ b/monroe/cli.py
@@ -24,6 +24,8 @@ mnr_key = str(mnr_dir) + 'mnrKey.pem'
 mnr_crt = str(mnr_dir) + 'mnrCrt.pem'
 sshkey = str(mnr_dir) + 'mnr_rsa.pub'
 sshkey_priv = str(mnr_dir) + 'mnr_rsa'
+ssh_customconf = str(mnr_dir) + 'mnr_config'
+sshhost_alias = 'c' # short name for connection (c for container)
 
 import logging
 logging.getLogger().setLevel(logging.DEBUG)
@@ -144,11 +146,16 @@ def create(args):
                 port = 30000 + item.nodeid()
                 con = check_server('193.10.227.35', port)
                 if con:
-                    cmd = " ".join([
-                        'ssh', '-o', 'StrictHostKeyChecking=no', '-o',
-                        'UserKnownHostsFile=/dev/null', '-i', sshkey_priv, '-p',
-                        str(port), 'root@tunnel.monroe-system.eu'
-                    ])
+                    with open(ssh_customconf, 'w') as f:
+                       f.writelines(['Host {}\n'.format(sshhost_alias),
+                                    '\tStrictHostKeyChecking no\n',
+                                    '\tUserKnownHostsFile /dev/null\n',
+                                    '\tUser root\n',
+                                    '\tIdentityFile {}\n'.format(sshkey_priv),
+                                    '\tHostName tunnel.monroe-system.eu\n',
+                                    '\tPort {}\n'.format(port)])
+                    cmd = "ssh -F {} {}".format(ssh_customconf, sshhost_alias)
+                    print('Connect string:\n{}\n'.format(cmd));
                     os.system(cmd)
         except Exception as err:
            raise SystemExit(err)


### PR DESCRIPTION
When working interactively it's valuable to be able to have multiple terminals and/or transfer files in/out of the container. This patch puts the parameters in a ssh config file, then you can just use "ssh c", or "scp script.py c:/tmp". (requires Include ~/.monroe/mnr_config  in ~/.ssh/config and openssh >7.3 with support for the include option. Otherwise just add -F ~/.monroe/mnr_config to the commands).

The connection string is now also printed when the connection is established for easy remembering/debugging/copy/paste.


Update 171211: Also added chmod'ing of the certificate key to make it user+rw only. 
