### PR TITLE
Adjust DELETE operation

### DIFF
--- a/monroe/core.py
+++ b/monroe/core.py
@@ -560,7 +560,7 @@ class Scheduler:
 
     def delete_experiment(self, experimentid):
         '''Requests a deletion for a given experiment ID.'''
-        endpoint = "/v1/experiments/%s/schedules" % str(experimentid)
+        endpoint = "/v1/experiments/%s" % str(experimentid)
         res = self.delete(endpoint)
         return res
 


### PR DESCRIPTION
DELETE operates on experiments, not on schedules. It works 'as is' because the scheduler ignores extra arguments, but Thomas noted this in the server logs and that it looked strange.